### PR TITLE
Add modern train in ASCII art

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # train-cli
-The cli tool show the running train
+The cli tool shows the running modern train in ASCII art
+
+## Example Output
+
+```
+        ____
+  __,-~~/~    `---.
+_/_,---(      ,    )
+ __/        <    /   )
+  ~~-~~/`---'~`--~
+```

--- a/main.go
+++ b/main.go
@@ -4,5 +4,14 @@ import "fmt"
 
 // This is the main entry point for the Train CLI application
 func main() {
-    fmt.Println("Train CLI application is running")
+    printTrain()
+}
+
+// printTrain prints a modern train in ASCII art
+func printTrain() {
+    fmt.Println("        ____")
+    fmt.Println("  __,-~~/~    `---.")
+    fmt.Println("_/_,---(      ,    )")
+    fmt.Println(" __/        <    /   )")
+    fmt.Println("  ~~-~~/`---'~`--~")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+    "bytes"
+    "testing"
+)
+
+func TestPrintTrain(t *testing.T) {
+    // Capture the output of printTrain
+    var buf bytes.Buffer
+    old := out
+    out = &buf
+    defer func() { out = old }()
+
+    printTrain()
+
+    // Expected ASCII art of the modern train
+    expected := "        ____\n  __,-~~/~    `---.\n_/_,---(      ,    )\n __/        <    /   )\n  ~~-~~/`---'~`--~\n"
+
+    if buf.String() != expected {
+        t.Errorf("Expected %q but got %q", expected, buf.String())
+    }
+}


### PR DESCRIPTION
Related to #4

Add functionality to print a modern train in ASCII art when the program is called.

* **main.go**
  - Add `printTrain` function to print a modern train in ASCII art.
  - Call `printTrain` function in the `main` function.

* **README.md**
  - Update description to mention that the program prints a modern train in ASCII art.
  - Add an example of the program's output showing the modern train in ASCII art.

* **main_test.go**
  - Add `TestPrintTrain` function to test the `printTrain` function.
  - Capture the output of `printTrain` and compare it with the expected ASCII art of the modern train.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fumiya-kume/train-cli/issues/4?shareId=42d9bf99-c186-4740-9d0b-c83face3b639).