### PR TITLE
Enable CI for all branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,7 @@ name: Lint
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,7 @@ name: Test
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # train-cli
 The cli tool show the running train
+
+## Continuous Integration (CI)
+The CI workflows for this repository are triggered on push and pull requests to any branch. This ensures that linting and testing are performed for all branches.


### PR DESCRIPTION
Related to #6

Enable CI workflows for all branches.

* **README.md**
  - Add a section describing the new CI behavior, indicating that CI workflows are triggered on push and pull requests to any branch.
* **.github/workflows/lint.yml**
  - Remove the `branches` specification under `push` and `pull_request` to enable CI for all branches.
* **.github/workflows/test.yml**
  - Remove the `branches` specification under `push` and `pull_request` to enable CI for all branches.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fumiya-kume/train-cli/issues/6?shareId=193b1864-b322-44c6-a5e9-c96d7390d215).